### PR TITLE
0.0.8 issue 11 created and deleting observers

### DIFF
--- a/app/Events/RemoteFeedDeleting.php
+++ b/app/Events/RemoteFeedDeleting.php
@@ -3,11 +3,8 @@
 namespace App\Events;
 
 use App\Models\RemoteFeeds;
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 

--- a/app/Listeners/RemoteFeedDeletingListener.php
+++ b/app/Listeners/RemoteFeedDeletingListener.php
@@ -6,12 +6,10 @@ namespace App\Listeners;
 use App\Customizations\Adapters\RedisFileCachingAdapter;
 use App\Events\RemoteFeedDeleting;
 use App\Models\DownloadedFiles;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Facades\Storage;
 
-class RemoteFeedDeletingListener implements ShouldQueue
+class RemoteFeedDeletingListener
 {
     private function unset(?DownloadedFiles $model): void
     {
@@ -26,7 +24,7 @@ class RemoteFeedDeletingListener implements ShouldQueue
     /**
      * Handle the event.
      */
-    public function handle(RemoteFeedDeleting $event): void
+    public function handle(RemoteFeedDeleting $event)
     {
         $this->unset($event->model->downloaded);
         $collection = $event->model->downloaded_files;

--- a/app/Models/RemoteFeeds.php
+++ b/app/Models/RemoteFeeds.php
@@ -25,12 +25,10 @@ class RemoteFeeds extends Model
     protected static function boot()
     {
         parent::boot();
-        static::created(function ($model) {
-            RemoteFeedCreated::dispatchIf(
-                $model->is_active,
-                $model->withoutRelations()
-            );
-        });
+        static::created(fn ($model) => RemoteFeedCreated::dispatchIf(
+            $model->is_active,
+            $model->withoutRelations()
+        ));
         static::deleting(fn ($model) => RemoteFeedDeleting::dispatch(
             $model->withoutRelations('pornstars')
         ));

--- a/app/Models/RemoteFeeds.php
+++ b/app/Models/RemoteFeeds.php
@@ -7,25 +7,32 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use App\Events\RemoteFeedCreated;
 use App\Events\RemoteFeedDeleting;
+use App\Jobs\Common\DownloadJob;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Support\Collection;
 
 class RemoteFeeds extends Model
 {
     use HasFactory;
 
+    /**
+     * {@inheritdoc}
+     */
     protected static function boot()
     {
         parent::boot();
-        static::created(fn ($model) => RemoteFeedCreated::dispatchIf(
-            $model->is_active,
-            $model->withoutRelations()
-        ));
+        static::created(function ($model) {
+            RemoteFeedCreated::dispatchIf(
+                $model->is_active,
+                $model->withoutRelations()
+            );
+        });
         static::deleting(fn ($model) => RemoteFeedDeleting::dispatch(
-            $model::withoutRelations('pornstars')
+            $model->withoutRelations('pornstars')
         ));
     }
 
@@ -42,27 +49,87 @@ class RemoteFeeds extends Model
     /**
      * {@inheritdoc}
      */
+    protected $appends = [
+        'chain',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
     protected $casts = [
         'handle'        => AsArrayObject::class,
     ];
 
+    /**
+     * Many to One Relation
+     *
+     * Gets the relation from `downloaded_files` table.
+     * Points to file stored within filesystem
+     *
+     * @access  public
+     * @return  BelongsTo
+     */
     public function downloaded(): BelongsTo
     {
         return $this->belongsTo(DownloadedFiles::class, 'downloaded_file_id');
     }
 
+    /**
+     * Many to Many Relation
+     *
+     * Gets the relation from `downloaded_files` table via `thumbnails`
+     * Points to images and other files stored within filesystem
+     *
+     * @access  public
+     * @return  HasManyThrough
+     */
     public function downloaded_files(): HasManyThrough
     {
         return $this->hasManyThrough(DownloadedFiles::class, Thumbnails::class, 'remote_feed_id', 'id', 'thumbnail_id');
     }
 
+    /**
+     * One to Many Relation
+     *
+     * Gets the relation from `pornstars` table.
+     *
+     * @access  public
+     * @return  HasMany
+     */
     public function pornstars(): HasMany
     {
         return $this->hasMany(Pornstars::class, 'remote_feed_id');
     }
 
+    /**
+     * One to Many Relation
+     *
+     * Gets the relation from `thumbnails` table.
+     *
+     * @access  public
+     * @return  HasMany
+     */
     public function thumbnails(): HasMany
     {
         return $this->hasMany(Thumbnails::class, 'remote_feed_id');
+    }
+
+    /**
+     * Custom Attribute
+     *
+     * Generates a chain of jobs from handle.
+     * Only structures them for when and if those jobs are needed.
+     *
+     * @access  public
+     * @return  Collection
+     */
+    public function getChainAttribute(): Collection
+    {
+        return collect($this->handle)
+            ->map(fn ($attributes, $class) => \class_exists($class) ? match ($class) {
+                DownloadJob::class => new $class($this, ...$attributes),
+                default            => new $class(...$attributes),
+            } : null)
+            ->filter(fn ($node) => $node !== null);
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -6696,16 +6696,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.2.5",
+            "version": "10.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "15a89f123d8ca9c1e1598d6d87a56a8bf28c72cd"
+                "reference": "1c17815c129f133f3019cc18e8d0c8622e6d9bcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/15a89f123d8ca9c1e1598d6d87a56a8bf28c72cd",
-                "reference": "15a89f123d8ca9c1e1598d6d87a56a8bf28c72cd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1c17815c129f133f3019cc18e8d0c8622e6d9bcd",
+                "reference": "1c17815c129f133f3019cc18e8d0c8622e6d9bcd",
                 "shasum": ""
             },
             "require": {
@@ -6777,7 +6777,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.5"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.6"
             },
             "funding": [
                 {
@@ -6793,7 +6793,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-14T04:18:47+00:00"
+            "time": "2023-07-17T12:08:28+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/database/factories/RemoteFeedsFactory.php
+++ b/database/factories/RemoteFeedsFactory.php
@@ -28,9 +28,9 @@ class RemoteFeedsFactory extends Factory
             'is_active'         => fake()->boolean(),
             'examine_counter'   => fake()->randomNumber(5),
             'download_counter'  => fake()->randomNumber(3),
-            'handle'            => '[]',
+            'handle'            => [],
             'created_at'        => Carbon::now(),
-            'updated_at'        => Carbon::now(),
+            'updated_at'        => null,
         ];
     }
 }

--- a/database/seeders/RemoteFeedsSeeder.php
+++ b/database/seeders/RemoteFeedsSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Jobs\Common\DownloadJob;
 use App\Jobs\Common\ThumbnailsJob;
 use App\Jobs\Pornhub\ProcessJob;
 use Carbon\Carbon;
@@ -24,7 +25,11 @@ class RemoteFeedsSeeder extends Seeder
                 'downloaded_file_id'=> null,
                 'source'            => 'https://www.pornhub.com/files/json_feed_pornstars.json',
                 'is_active'         => true,
-                'handle'            => \json_encode([ProcessJob::class => [1], ThumbnailsJob::class => [1]]),
+                'handle'            => \json_encode([
+                    DownloadJob::class  => [],
+                    ProcessJob::class   => [1],
+                    ThumbnailsJob::class=> [1],
+                ]),
                 'created_at'        => Carbon::now(),
                 'updated_at'        => null,
             ]

--- a/resources/js/Components/Product.jsx
+++ b/resources/js/Components/Product.jsx
@@ -81,7 +81,7 @@ export default function Product({ auth, product }) {
             </p>
             <p className={styles.p}>
                 <b>Updated</b>
-                <span>{dayjs(updated_at).fromNow()}</span>
+                <span>{updated_at != null ? dayjs(updated_at).fromNow() : "-"}</span>
             </p>
         </div>
     );

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,19 +72,11 @@ Route::name('products.')->prefix('products')->group(function () {
             Redirect::back()->with(['status' => 404, 'message' => 'These are not the droids you are looking for']);
         }
 
-        $chain = [
-            new DownloadJob($model),
-        ];
-
-        collect($model->handle)->map(function ($attributes, $class) use (&$chain) {
-            if (class_exists($class)) {
-                $chain[] = new $class(...$attributes);
-            }
-        });
-
-        Bus::chain($chain)
-            ->onQueue('downloads')
-            ->dispatch();
+        if ($model->chain->isEmpty() === false) {
+            Bus::chain($model->chain)
+                ->onQueue('downloads')
+                ->dispatch();
+        }
 
         return Redirect::back()->with(['status' => 200, 'message' => 'job dispatched']);
     })->middleware(['auth', 'verified'])->name('job');

--- a/tests/Feature/Models/PornstarsTest.php
+++ b/tests/Feature/Models/PornstarsTest.php
@@ -48,15 +48,15 @@ class PornstarsTest extends TestCase
         $this->assertDatabaseCount('pornstars', 5);
 
         $keys = Thumbnails::all()->modelKeys();
-        Pornstars::all()->map(function ($model) use ($keys) {
-            $key = $keys[\intval($model->id%2 === 0)];
+        Pornstars::all()->map(function ($model, $i) use ($keys) {
+            $key = $keys[\intval($i%2 === 0)];
             $thumbnail = $this->thumbnails->find($key);
             $model->thumbnails()->sync($thumbnail);
             $model->save();
         });
 
-        $this->assertSame(3, PornstarsThumbnails::where(['thumbnail_id' => $keys[0]])->get()->count());
-        $this->assertSame(2, PornstarsThumbnails::where(['thumbnail_id' => $keys[1]])->get()->count());
+        $this->assertSame(2, PornstarsThumbnails::where(['thumbnail_id' => $keys[0]])->get()->count());
+        $this->assertSame(3, PornstarsThumbnails::where(['thumbnail_id' => $keys[1]])->get()->count());
 
         $sut = Pornstars::first();
 

--- a/tests/Feature/Models/RemoteFeedsTest.php
+++ b/tests/Feature/Models/RemoteFeedsTest.php
@@ -3,31 +3,35 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Models;
 
+use App\Events\RemoteFeedCreated;
+use App\Events\RemoteFeedDeleting;
+use App\Jobs\Common\DownloadJob;
+use App\Listeners\RemoteFeedCreatedListener;
+use App\Listeners\RemoteFeedDeletingListener;
+use App\Models\DownloadedFiles;
 use App\Models\RemoteFeeds;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\TestCase;
 
 #[CoversClass(RemoteFeeds::class)]
+#[UsesClass(RemoteFeedCreated::class)]
+#[UsesClass(RemoteFeedCreatedListener::class)]
 class RemoteFeedsTest extends TestCase
 {
+    #[Group('success')]
     #[Group('seed')]
     public function test_success_seed()
     {
         $this->assertDatabaseCount('remote_feeds', 1);
     }
 
-    #[Group('factory')]
-    #[Group('without-events')]
-    public function test_success_factory()
-    {
-        RemoteFeeds::unsetEventDispatcher();
-        RemoteFeeds::factory()->count(5)->create();
-        $this->assertDatabaseCount('remote_feeds', 6);
-    }
-
+    #[Group('success')]
+    #[Group('seed')]
     #[Group('relations')]
     public function test_success_seed_relations()
     {
@@ -35,18 +39,139 @@ class RemoteFeedsTest extends TestCase
         $this->assertSame(0, $sut->pornstars->count());
         $this->assertSame(0, $sut->thumbnails->count());
         $this->assertSame(0, $sut->downloaded_files->count());
-        $this->assertSame(null, $sut->downloaded);
+        $this->assertNull($sut->downloaded);
+    }
+
+    #[Group('success')]
+    #[Group('factory')]
+    #[Group('without-events')]
+    public function test_success_factory_without_events()
+    {
+        RemoteFeeds::unsetEventDispatcher();
+        RemoteFeeds::factory()->count(5)->create();
+        $this->assertDatabaseCount('remote_feeds', 6);
     }
 
     #[Group('factory')]
-    #[Group('relations')]
+    #[Group('success')]
     #[Group('without-events')]
-    public function test_success_factory_relations()
+    #[Group('chain')]
+    public function test_success_chain_without_events()
     {
-        // RemoteFeeds::unsetEventDispatcher();
-        $sut = RemoteFeeds::all()->except([1]);
-        $this->assertSame(0, $sut->count());
+        RemoteFeeds::unsetEventDispatcher();
+        $collection = RemoteFeeds::factory()->count(1)->create([
+            'source'    => "https://place-hold.it/244x344/666321/123666.jpg&text=lorem-ipsum&bold&italic&fontsize=11",
+            'is_active' => true,
+            'handle'    => [DownloadJob::class => ['moufa']],
+            'name'      => 'PlaceHoldJPG',
+        ]);
+        
 
-        // add some new factory content here
+        $sut = $collection->first();
+        $this->assertInstanceOf(Collection::class, $sut->chain);
+        $this->assertTrue($sut->chain->isNotEmpty());
+        $this->assertInstanceOf(DownloadJob::class, $sut->chain->first());
+    }
+
+    #[Group('factory')]
+    #[Group('failure')]
+    #[Group('without-events')]
+    #[Group('chain')]
+    public function test_failure_chain_without_events()
+    {
+        RemoteFeeds::unsetEventDispatcher();
+        $collection = RemoteFeeds::factory()->count(1)->create([
+            'source'    => "https://place-hold.it/244x344/666321/123666.jpg&text=lorem-ipsum&bold&italic&fontsize=11",
+            'is_active' => true,
+            'handle'    => ['notAClass' => [], 'thisIsNotAnotherClass' => [123]],
+            'name'      => 'PlaceHoldJPG',
+        ]);
+        
+        $sut = $collection->first();
+        $this->assertInstanceOf(Collection::class, $sut->chain);
+        $this->assertTrue($sut->chain->isEmpty());
+    }
+
+    #[Group('factory')]
+    #[Group('failure')]
+    #[Group('observer')]
+    #[Group('created')]
+    public function test_failure_observer_created()
+    {
+        /**
+         * @var FilesystemManager $storage
+         */
+        Storage::fake('moufa');
+        Event::fake([
+            RemoteFeedCreated::class
+        ]);
+
+        Event::assertListening(RemoteFeedCreated::class, RemoteFeedCreatedListener::class);
+
+        RemoteFeeds::factory()->count(1)->create([
+            'source'    => "https://place-hold.it/244x344/666321/123666.png&text=lorem-ipsum&bold&italic&fontsize=11",
+            'is_active' => false,
+            'handle'    => [DownloadJob::class => ['moufa']],
+            'name'      => 'PlaceHoldPNG',
+        ]);
+
+        Event::assertNotDispatched(RemoteFeedCreated::class);
+        $this->assertDatabaseHas(app(RemoteFeeds::class)->getTable(), ['name' => 'PlaceHoldPNG']);
+    }
+
+    #[Group('factory')]
+    #[Group('success')]
+    #[Group('observer')]
+    #[Group('created')]
+    public function test_success_observer_created()
+    {
+        /**
+         * @var FilesystemManager $storage
+         */
+        Storage::fake('moufa');
+        Event::fake([
+            RemoteFeedCreated::class
+        ]);
+
+        Event::assertListening(RemoteFeedCreated::class, RemoteFeedCreatedListener::class);
+
+        RemoteFeeds::factory()->count(1)->create([
+            'source'    => "https://place-hold.it/244x344/666321/123666.jpg&text=lorem-ipsum&bold&italic&fontsize=11",
+            'is_active' => true,
+            'handle'    => [DownloadJob::class => ['moufa']],
+            'name'      => 'PlaceHoldJPG',
+        ]);
+
+        Event::assertDispatched(RemoteFeedCreated::class);
+        $this->assertDatabaseHas(app(RemoteFeeds::class)->getTable(), ['name' => 'PlaceHoldJPG']);
+    }
+
+    #[Group('factory')]
+    #[Group('success')]
+    #[Group('observer')]
+    #[Group('deleting')]
+    public function test_success_observer_deleting()
+    {
+        /**
+         * @var FilesystemManager $storage
+         */
+        $storage = Storage::fake('moufa');
+        Event::fake([
+            RemoteFeedDeleting::class
+        ]);
+
+        Event::assertListening(RemoteFeedDeleting::class, RemoteFeedDeletingListener::class);
+
+        $sut = RemoteFeeds::factory()->count(1)->create([
+            'source'    => "https://place-hold.it/244x344/666321/123666.jpg&text=lorem-ipsum&bold&italic&fontsize=11",
+            'is_active' => true,
+            'handle'    => [DownloadJob::class => ['moufa']],
+            'name'      => 'PlaceHoldJPG',
+        ])->first();
+
+        $this->assertNotNull($sut->downloaded_file_id);
+        $sut->delete();
+        Event::assertDispatched(RemoteFeedDeleting::class);
+        $this->assertDatabaseMissing(app(RemoteFeeds::class)->getTable(), ['name' => 'PlaceHoldJPG']);
     }
 }

--- a/tests/Feature/Models/ThumbnailsTest.php
+++ b/tests/Feature/Models/ThumbnailsTest.php
@@ -47,8 +47,8 @@ class ThumbnailsTest extends TestCase
         $this->assertDatabaseCount('thumbnails', 5);
 
         $keys = $this->pornstars->modelKeys();
-        $collection->map(function ($model) use ($keys) {
-            $key = $keys[\intval($model->id%2 === 0)];
+        $collection->map(function ($model, $i) use ($keys) {
+            $key = $keys[\intval($i%2 === 0)];
             $pornstar = $this->pornstars->find($key);
             $model->pornstars()->sync($pornstar);
             $model->save();


### PR DESCRIPTION
Various fixes for both observers and tested behavior
Additionally added attribute chain per remote_feed, this way you can declare any type of job, in any order without Downloading from the source (previous behavior).
Minor test fixes on other models